### PR TITLE
[FEATURE] #8, 여행지 입력 후 해당 여행지의 혼잡도 관계없이 포함되도록 수정

### DIFF
--- a/src/main/java/com/opendata/domain/course/controller/CourseController.java
+++ b/src/main/java/com/opendata/domain/course/controller/CourseController.java
@@ -25,13 +25,15 @@ public class CourseController {
 
     @GetMapping("/get")
     public ResponseEntity<ApiResponse<CourseResultResponse>> findCourses(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            //@AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam double lat,
             @RequestParam double lon,
             @RequestParam String startTime,
-            @RequestParam String endTime){
+            @RequestParam String endTime,
+            @RequestParam String tourspot
+            ){
         return ResponseEntity.ok(ApiResponse.onSuccess(
-                courseService.recommendCourses(customUserDetails, lat, lon, startTime, endTime)));
+                courseService.recommendCourses(lat, lon, startTime, endTime, tourspot)));
     }
 
     @PostMapping("/like")

--- a/src/main/java/com/opendata/domain/course/service/CourseService.java
+++ b/src/main/java/com/opendata/domain/course/service/CourseService.java
@@ -30,11 +30,10 @@ public class CourseService {
     private final UserRepository userRepository;
 
 
-    public CourseResultResponse recommendCourses(CustomUserDetails customUserDetails, double userLat, double userLon, String startTime, String endTime) {
-        User user = customUserDetails.getUser();
+    public CourseResultResponse recommendCourses( double userLat, double userLon, String startTime, String endTime, String tourspot) {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
-        List<FilteredArea> candidates = getFilteredCandidates(userLat, userLon, startTime, endTime, formatter);
+        List<FilteredArea> candidates = getFilteredCandidates(userLat, userLon, startTime, endTime, tourspot, formatter);
 
         List<List<AreaComponentDto>> resultCourses = new ArrayList<>();
         Set<String> usedAreaIds = new HashSet<>();
@@ -45,17 +44,17 @@ public class CourseService {
                 resultCourses.add(course);
                 course.forEach(a -> usedAreaIds.add(a.name()));
             }
-            if (resultCourses.size() >= user.getMemberShip().getCourseLimit()) break;
+            if (resultCourses.size() >= 5) break;
         }
 
         return CourseResultResponse.from(resultCourses, resultCourses.size(), startTime, endTime);
     }
 
-    private List<FilteredArea> getFilteredCandidates(double userLat, double userLon, String startTime, String endTime, DateTimeFormatter formatter) {
+    private List<FilteredArea> getFilteredCandidates(double userLat, double userLon, String startTime, String endTime, String tourspot, DateTimeFormatter formatter) {
         return areaRepository.findAll().stream()
                 .flatMap(area -> area.getFutures().stream()
                         .filter(f -> isInTimeRange(f.getFcstTime(), startTime, endTime))
-                        .filter(f -> f.getFcstCongestLvl().equals("여유") || f.getFcstCongestLvl().equals("보통"))
+                        .filter(f -> f.getFcstCongestLvl().equals("여유") || f.getFcstCongestLvl().equals("보통") || area.getName().equals(tourspot))
                         .map(f -> new FilteredArea(
                                 area.getId(),
                                 area.getName(),


### PR DESCRIPTION
- 기존 코드는 입력한 여행지의 혼잡도가 '보통' 이상이면 코스 구성에서 제외되었으나 포함되도록 수정


```
@GetMapping("/get")
    public ResponseEntity<ApiResponse<CourseResultResponse>> findCourses(
            //@AuthenticationPrincipal CustomUserDetails customUserDetails,
            @RequestParam double lat,
            @RequestParam double lon,
            @RequestParam String startTime,
            @RequestParam String endTime,
            @RequestParam String tourspot
            ){
        return ResponseEntity.ok(ApiResponse.onSuccess(
                courseService.recommendCourses(lat, lon, startTime, endTime, tourspot)));
    }
```

```
private List<FilteredArea> getFilteredCandidates(double userLat, double userLon, String startTime, String endTime, String tourspot, DateTimeFormatter formatter) {
        return areaRepository.findAll().stream()
                .flatMap(area -> area.getFutures().stream()
                        .filter(f -> isInTimeRange(f.getFcstTime(), startTime, endTime))
                        .filter(f -> f.getFcstCongestLvl().equals("여유") || f.getFcstCongestLvl().equals("보통") || 
// 이 부분 추가
area.getName().equals(tourspot))
                        .map(f -> new FilteredArea(
                                area.getId(),
                                area.getName(),
                                area.getCategory(),
                                area.getDescription(),
                                area.getImage(),
                                area.isIndoor(),
                                area.getLatitude(),
                                area.getLongitude(),
                                area.getCongestion_level(),
                                area.getEvents(),
                                LocalDateTime.parse(f.getFcstTime(), formatter)
                        ))
                )
                .filter(a -> CourseUtil.calculateDistance(userLat, userLon, a.lat(), a.lon()) <= 30.0)
                .toList();
    }
```