### PR TITLE
[feat] 관광지 상세 정보 반환

### DIFF
--- a/src/main/java/com/opendata/domain/address/entity/Address.java
+++ b/src/main/java/com/opendata/domain/address/entity/Address.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Entity
 @Table(name = "address")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
@@ -25,8 +26,8 @@ public class Address extends BaseEntity {
     @Column(name = "address_kor_nm")
     private String addressKorNm;
 
-    @Column(name = "address_eng_nm")
-    private String addressEngNm;
+    @Column(name = "address_detail")
+    private String addressDetail;
 
     @Column(name = "latitude")
     private Double latitude;

--- a/src/main/java/com/opendata/domain/tourspot/controller/TourSpotController.java
+++ b/src/main/java/com/opendata/domain/tourspot/controller/TourSpotController.java
@@ -1,12 +1,16 @@
 package com.opendata.domain.tourspot.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.opendata.domain.tourspot.dto.AreaCongestionDto;
+import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
 import com.opendata.domain.tourspot.entity.enums.CongestionLevel;
 import com.opendata.domain.tourspot.service.TourSpotService;
 import com.opendata.global.response.ApiResponse;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,11 +24,16 @@ public class TourSpotController
     private final TourSpotService tourSpotService;
 
     @GetMapping
-    public ResponseEntity<Void> getArea()
-    {
+    public ResponseEntity<Void> getArea() {
         tourSpotService.fetchAllAreaAndSave();
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/{tourspotId}")
+    public ResponseEntity<ApiResponse<TourSpotDetailResponse>> getTourSpotDetail(@PathVariable("tourspotId") Long tourspotId) throws JsonProcessingException {
+        return ResponseEntity.ok(ApiResponse.onSuccess(tourSpotService.combineTourSpotDetail(tourspotId)));
+    }
+
 
 
 //    @GetMapping("/list")

--- a/src/main/java/com/opendata/domain/tourspot/controller/TourSpotGeoCodeController.java
+++ b/src/main/java/com/opendata/domain/tourspot/controller/TourSpotGeoCodeController.java
@@ -1,0 +1,22 @@
+//package com.opendata.domain.tourspot.controller;
+//
+//import com.opendata.domain.tourspot.service.TourSpotGeoCodeService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//@RestController
+//@RequestMapping("/api/tourspot")
+//@RequiredArgsConstructor
+//public class TourSpotGeoCodeController {
+//
+//    private final TourSpotGeoCodeService tourSpotGeoCodeService;
+//
+//    @PostMapping("/geocode")
+//    public ResponseEntity<String> fetchAndInsertTourSpotData() {
+//        tourSpotGeoCodeService.processTourSpots();
+//        return ResponseEntity.ok("✅ 관광지 데이터 처리 완료");
+//    }
+//}

--- a/src/main/java/com/opendata/domain/tourspot/dto/AddressDto.java
+++ b/src/main/java/com/opendata/domain/tourspot/dto/AddressDto.java
@@ -1,0 +1,8 @@
+package com.opendata.domain.tourspot.dto;
+
+public record AddressDto(
+        String addressKorNm,
+        String addressDetail,
+        String latitude,
+        String longitude
+) {}

--- a/src/main/java/com/opendata/domain/tourspot/dto/TourSpotEventDto.java
+++ b/src/main/java/com/opendata/domain/tourspot/dto/TourSpotEventDto.java
@@ -1,0 +1,12 @@
+package com.opendata.domain.tourspot.dto;
+
+public record TourSpotEventDto(
+        Long tourspotEventId,
+        String eventName,
+        String eventPeriod,
+        String eventPlace,
+        Double eventX,
+        Double eventY,
+        String tourspotThumbnail,
+        String tourspotUrl
+) {}

--- a/src/main/java/com/opendata/domain/tourspot/dto/TourSpotTagDto.java
+++ b/src/main/java/com/opendata/domain/tourspot/dto/TourSpotTagDto.java
@@ -1,0 +1,5 @@
+package com.opendata.domain.tourspot.dto;
+
+public record TourSpotTagDto(
+        String tourSpotCategory
+) {}

--- a/src/main/java/com/opendata/domain/tourspot/dto/response/TourSpotDetailResponse.java
+++ b/src/main/java/com/opendata/domain/tourspot/dto/response/TourSpotDetailResponse.java
@@ -1,0 +1,26 @@
+package com.opendata.domain.tourspot.dto.response;
+
+
+import com.opendata.domain.tourspot.dto.AddressDto;
+import com.opendata.domain.tourspot.dto.TourSpotEventDto;
+import com.opendata.domain.tourspot.dto.TourSpotTagDto;
+import com.opendata.domain.tourspot.entity.TourSpotEvent;
+import com.opendata.domain.tourspot.entity.TourSpotTag;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TourSpotDetailResponse {
+    private String tourspotNm;
+    private AddressDto address;
+    private String congestionLabel;
+    private List<TourSpotEventDto> tourSpotEvents;
+    private List<TourSpotTagDto> tourSpotTags;
+}

--- a/src/main/java/com/opendata/domain/tourspot/entity/TourSpotTag.java
+++ b/src/main/java/com/opendata/domain/tourspot/entity/TourSpotTag.java
@@ -1,0 +1,22 @@
+package com.opendata.domain.tourspot.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "tourspot_tag")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TourSpotTag extends TourSpotAssociated{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tourSpotTagId;
+
+    @Column(name = "tourspot_category")
+    private String tourSpotCategory;
+
+}

--- a/src/main/java/com/opendata/domain/tourspot/mapper/MonthlyCongestionMapper.java
+++ b/src/main/java/com/opendata/domain/tourspot/mapper/MonthlyCongestionMapper.java
@@ -16,8 +16,6 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
         imports = CongestionLevel.class
 )
 public interface MonthlyCongestionMapper {
-    MonthlyCongestionMapper INSTANCE = Mappers.getMapper(MonthlyCongestionMapper.class);
-
 
     @Mapping(target = "baseYmd", source = "baseYmd")
     @Mapping(target = "congestionLvl", expression = "java(CongestionLevel.fromRate(dto.getCnctrRate()))")

--- a/src/main/java/com/opendata/domain/tourspot/mapper/TourSpotDetailMapper.java
+++ b/src/main/java/com/opendata/domain/tourspot/mapper/TourSpotDetailMapper.java
@@ -1,0 +1,42 @@
+package com.opendata.domain.tourspot.mapper;
+
+import com.opendata.domain.address.entity.Address;
+import com.opendata.domain.tourspot.dto.AddressDto;
+import com.opendata.domain.tourspot.dto.CityDataDto;
+import com.opendata.domain.tourspot.dto.TourSpotEventDto;
+import com.opendata.domain.tourspot.dto.TourSpotTagDto;
+import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
+import com.opendata.domain.tourspot.entity.TourSpotEvent;
+import com.opendata.domain.tourspot.entity.TourSpotTag;
+import com.opendata.domain.tourspot.entity.enums.CongestionLevel;
+import org.mapstruct.*;
+
+import java.util.List;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(componentModel = SPRING,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        imports = CongestionLevel.class)
+public interface TourSpotDetailMapper {
+
+    @Mapping(target = "tourspotNm", source = "tourSpot.tourspotNm")
+    @Mapping(target = "address", source = "address")
+    @Mapping(target = "congestionLabel", source = "congestion")
+    @Mapping(target = "tourSpotEvents", source = "events")
+    @Mapping(target = "tourSpotTags", source = "tags")
+    TourSpotDetailResponse toResponse(
+            TourSpot tourSpot,
+            AddressDto address,
+            String congestion,
+            List<TourSpotEventDto> events,
+            List<TourSpotTagDto> tags
+    );
+
+    List<TourSpotEventDto> toEventDtos(List<TourSpotEvent> events);
+    List<TourSpotTagDto> toTagDtos(List<TourSpotTag> tags);
+    AddressDto toAddressDto(Address address);
+
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/CurrentCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/CurrentCongestionRepository.java
@@ -1,0 +1,10 @@
+package com.opendata.domain.tourspot.repository;
+
+import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
+import com.opendata.domain.tourspot.repository.custom.CustomCurrentCongestionRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CurrentCongestionRepository extends JpaRepository<TourSpotCurrentCongestion, Long>, CustomCurrentCongestionRepository {
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/TourSpotTagRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/TourSpotTagRepository.java
@@ -1,0 +1,10 @@
+package com.opendata.domain.tourspot.repository;
+
+import com.opendata.domain.tourspot.entity.TourSpotTag;
+import com.opendata.domain.tourspot.repository.custom.CustomTourSpotTagRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TourSpotTagRepository extends JpaRepository<TourSpotTag, Long>, CustomTourSpotTagRepository {
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomCurrentCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomCurrentCongestionRepository.java
@@ -1,0 +1,8 @@
+package com.opendata.domain.tourspot.repository.custom;
+
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
+
+public interface CustomCurrentCongestionRepository {
+    TourSpotCurrentCongestion findByTourSpotAndCurTime(TourSpot tourSpot, String fsctTime);
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomCurrentCongestionRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomCurrentCongestionRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.opendata.domain.tourspot.repository.custom;
+
+import com.opendata.domain.tourspot.entity.QTourSpotCurrentCongestion;
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
+import com.querydsl.core.QueryFactory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomCurrentCongestionRepositoryImpl implements CustomCurrentCongestionRepository{
+
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public TourSpotCurrentCongestion findByTourSpotAndCurTime(TourSpot tourSpot, String fsctTime) {
+        QTourSpotCurrentCongestion qTourSpotCurrentCongestion = QTourSpotCurrentCongestion.tourSpotCurrentCongestion;
+
+        return queryFactory.selectFrom(qTourSpotCurrentCongestion)
+                .where(qTourSpotCurrentCongestion.tourspot.eq(tourSpot), qTourSpotCurrentCongestion.fcstTime.eq(fsctTime))
+                .fetchFirst();
+    }
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotEventRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotEventRepository.java
@@ -1,5 +1,11 @@
 package com.opendata.domain.tourspot.repository.custom;
 
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotEvent;
+
+import java.util.List;
+
 public interface CustomTourSpotEventRepository {
     boolean existsByEventNameAndEventPeriod(String eventName, String eventPeriod);
+    List<TourSpotEvent> findAllByTourSpot(TourSpot tourSpot);
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotEventRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotEventRepositoryImpl.java
@@ -1,9 +1,13 @@
 package com.opendata.domain.tourspot.repository.custom;
 
 import com.opendata.domain.tourspot.entity.QTourSpotEvent;
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotEvent;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,5 +28,13 @@ public class CustomTourSpotEventRepositoryImpl implements CustomTourSpotEventRep
                 )
                 .fetchFirst();
         return fetchOne != null;
+    }
+
+    @Override
+    public List<TourSpotEvent> findAllByTourSpot(TourSpot tourSpot) {
+        QTourSpotEvent qTourSpotEvent = QTourSpotEvent.tourSpotEvent;
+        return queryFactory.selectFrom(qTourSpotEvent)
+                .where(qTourSpotEvent.tourspot.eq(tourSpot))
+                .fetch();
     }
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotRepository.java
@@ -1,9 +1,11 @@
 package com.opendata.domain.tourspot.repository.custom;
 
+import com.opendata.domain.address.entity.Address;
 import com.opendata.domain.tourspot.entity.TourSpot;
 
 import java.util.Optional;
 
 public interface CustomTourSpotRepository {
     Optional<TourSpot> findByName(String name);
+    Optional<TourSpot> findByAddress(Address address);
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.opendata.domain.tourspot.repository.custom;
 
+import com.opendata.domain.address.entity.Address;
 import com.opendata.domain.tourspot.entity.QTourSpot;
 import com.opendata.domain.tourspot.entity.TourSpot;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,5 +24,15 @@ public class CustomTourSpotRepositoryImpl implements CustomTourSpotRepository{
                 .fetchFirst();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Optional<TourSpot> findByAddress(Address address) {
+        QTourSpot qTourSpot = QTourSpot.tourSpot;
+
+        TourSpot tourSpot = queryFactory.selectFrom(qTourSpot)
+                .where(qTourSpot.address.eq(address))
+                .fetchFirst();
+        return Optional.ofNullable(tourSpot);
     }
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotTagRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotTagRepository.java
@@ -1,0 +1,10 @@
+package com.opendata.domain.tourspot.repository.custom;
+
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotTag;
+
+import java.util.List;
+
+public interface CustomTourSpotTagRepository {
+    List<TourSpotTag> findAllByTourSpot(TourSpot tourSpot);
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotTagRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotTagRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.opendata.domain.tourspot.repository.custom;
+
+import com.opendata.domain.tourspot.entity.QTourSpotTag;
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotTag;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomTourSpotTagRepositoryImpl implements CustomTourSpotTagRepository{
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public List<TourSpotTag> findAllByTourSpot(TourSpot tourSpot) {
+        QTourSpotTag qTourSpotTag = QTourSpotTag.tourSpotTag;
+        return queryFactory.selectFrom(qTourSpotTag)
+                .where(qTourSpotTag.tourspot.eq(tourSpot))
+                .fetch();
+    }
+}

--- a/src/main/java/com/opendata/domain/tourspot/service/TourSpotGeoCodeService.java
+++ b/src/main/java/com/opendata/domain/tourspot/service/TourSpotGeoCodeService.java
@@ -1,0 +1,140 @@
+//package com.opendata.domain.tourspot.service;
+//
+//import com.fasterxml.jackson.databind.JsonNode;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.opendata.domain.address.cache.AddressCache;
+//import com.opendata.domain.address.entity.Address;
+//import com.opendata.domain.address.repository.AddressRepository;
+//import com.opendata.domain.tourspot.entity.TourSpot;
+//import com.opendata.domain.tourspot.entity.TourSpotTag;
+//import com.opendata.domain.tourspot.repository.TourSpotRepository;
+//import com.opendata.domain.tourspot.repository.TourSpotTagRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//import org.springframework.web.reactive.function.client.WebClient;
+//
+//import java.util.Arrays;
+//import java.util.List;
+//import java.util.Optional;
+//import java.util.stream.Collectors;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class TourSpotGeoCodeService {
+//
+//    private static final String KAKAO_API_KEY = "KakaoAK 799fc99c89927abb8832e201e58c6a88";
+//    private static final String KAKAO_API_BASE = "https://dapi.kakao.com";
+//
+//    private final ObjectMapper mapper = new ObjectMapper();
+//
+//    private final AddressRepository addressRepository;
+//    private final TourSpotRepository tourSpotRepository;
+//    private final TourSpotTagRepository tourSpotTagRepository;
+//
+//    private final WebClient webClient = WebClient.builder()
+//            .baseUrl(KAKAO_API_BASE)
+//            .defaultHeader("Authorization", KAKAO_API_KEY)
+//            .build();
+//
+//    @Transactional
+//    public void processTourSpots() {
+//        List<Address> addresses = addressRepository.findAll();
+//        for (Address addr : addresses) {
+//            String query = "서울 " + addr.getAddressKorNm();
+//
+//            // Kakao API 호출
+//            JsonNode doc = callKakaoApi(query);
+//
+//            if (doc == null || doc.isMissingNode() || doc.isEmpty()) {
+//                System.out.printf("-- No result: %s%n", addr.getAddressKorNm());
+//                sleepQuietly(250);
+//                continue;
+//            }
+//
+//            // 좌표/주소/카테고리 추출
+//            String addressName = doc.path("address_name").asText(null);
+//            String rawCategory = doc.path("category_name").asText("");
+//
+//            if (addressName != null) {
+//                addr.setAddressDetail(addressName);
+//                addressRepository.save(addr);
+//            }
+//
+//            // 기존 TourSpot 가져오기 (주소 기준)
+//            Optional<TourSpot> maybeTourSpot = tourSpotRepository.findByAddress(addr);
+//            if (maybeTourSpot.isEmpty()) {
+//                System.out.printf("-- TourSpot 없음: %s%n", addr.getAddressKorNm());
+//                sleepQuietly(250);
+//                continue;
+//            }
+//            TourSpot tourSpot = maybeTourSpot.get();
+//
+//            // 카테고리 파싱
+//            List<String> categories = Arrays.stream(rawCategory.split(">"))
+//                    .map(String::trim)
+//                    .flatMap(part -> Arrays.stream(part.split(",")))
+//                    .map(String::trim)
+//                    .filter(s -> !s.isEmpty())
+//                    .distinct()
+//                    .collect(Collectors.toList());
+//
+//            for (String category : categories) {
+//                // 중복 태그 방지하려면 findExisting or unique constraint 검사 추가 가능
+//                TourSpotTag tag = TourSpotTag.builder()
+//                        .tourSpotCategory(category)
+//                        .build();
+//                tag.assignTourSpot(tourSpot);
+//                tourSpotTagRepository.save(tag);
+//            }
+//
+//            sleepQuietly(250);
+//        }
+//
+//        System.out.println("✅ All processing done.");
+//    }
+//
+//    private JsonNode callKakaoApi(String query) {
+//        try {
+//            var responseEntity = webClient.get()
+//                    .uri(uriBuilder ->
+//                            uriBuilder
+//                                    .path("/v2/local/search/keyword.json")
+//                                    .queryParam("query", query)
+//                                    .build()
+//                    )
+//                    .retrieve()
+//                    .onStatus(status -> !status.is2xxSuccessful(), clientResponse -> {
+//                        System.err.printf("[KakaoAPI] 비정상 상태 코드 %s for '%s'%n", clientResponse.statusCode(), query);
+//                        return clientResponse.createException();
+//                    })
+//                    .bodyToMono(String.class)
+//                    .block();
+//
+//            if (responseEntity == null) {
+//                System.err.printf("[KakaoAPI] 빈 바디 응답: '%s'%n", query);
+//                return null;
+//            }
+//
+//            JsonNode root = mapper.readTree(responseEntity);
+//            System.out.printf("[KakaoAPI] full response for '%s': %s%n", query, root.toString());
+//
+//            JsonNode docs = root.path("documents");
+//            if (docs.isArray() && docs.size() > 0) {
+//                return docs.get(0);
+//            } else {
+//                System.out.printf("[KakaoAPI] documents 비어있음 for '%s'%n", query);
+//                return null;
+//            }
+//        } catch (Exception e) {
+//            System.err.printf("-- Kakao API error for '%s': %s%n", query, e.getMessage());
+//            return null;
+//        }
+//    }
+//
+//    private void sleepQuietly(long ms) {
+//        try {
+//            Thread.sleep(ms);
+//        } catch (InterruptedException ignored) { }
+//    }
+//}

--- a/src/main/java/com/opendata/global/config/SecurityConfig.java
+++ b/src/main/java/com/opendata/global/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/oauth2/**","/register/*","/login/oauth2/**", "/swagger-ui/**",    // Swagger UI 관련 경로
-                                "/v3/api-docs/**","/api/area", "/course","/","/login").permitAll()
+                                "/v3/api-docs/**","/api/area/**", "/course","/","/login").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login((oauth2) -> oauth2

--- a/src/main/java/com/opendata/global/util/DateUtil.java
+++ b/src/main/java/com/opendata/global/util/DateUtil.java
@@ -15,4 +15,14 @@ public class DateUtil {
         LocalDateTime dateTime = LocalDateTime.parse(isoDateTime);
         return dateTime.format(FORMATTER);
     }
+
+    public static LocalDateTime floorToHour(LocalDateTime dateTime) {
+        return dateTime.withMinute(0).withSecond(0).withNano(0);
+    }
+
+    public static String getCurrentFormattedCurrentDateTime() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime floored = floorToHour(now);
+        return floored.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
 }


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- 관광지 이름, 주소, 혼잡도, 행사, 태그 정보 반환 API 구현
<img width="592" height="618" alt="image" src="https://github.com/user-attachments/assets/96246f0c-e333-4a2a-9313-667245859447" />
---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- TourSpotDetailResponse Dto와 Mapper 생성


---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #41

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->
- 지금 우리가 사용중인 엔티티들은 모두 BaseEntity를 상속 받고 있는데, LocalDateTime이 필드로 들어가있음. LocalDateTime 은 Java -> Json으로 직렬화할 때 Jackson이 처리를 못해서, LocalDateTime을 제거한 Dto로 선변환한 뒤 응답 Dto에 포함시키는 방식.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관광지 상세 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 관광지 태그, 이벤트, 주소, 혼잡도 등 상세 정보를 포함하는 응답 구조가 도입되었습니다.
  * 관광지 태그 및 혼잡도, 이벤트 관련 데이터 조회 및 매핑 기능이 추가되었습니다.
  * Kakao API를 활용한 관광지 주소 및 태그 자동 등록 기능이 추가되었습니다.
  * 시간 단위로 내림 처리된 현재 시각을 반환하는 유틸리티 기능이 추가되었습니다.

* **버그 수정**
  * 주소 엔티티 필드 및 매핑이 개선되었습니다.

* **보안 및 접근성**
  * "/api/area/**" 경로 전체에 대한 접근 허용 범위가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->