### PR TITLE
[feat] 마이페이지 구현

### DIFF
--- a/src/main/java/com/opendata/docs/CourseControllerDocs.java
+++ b/src/main/java/com/opendata/docs/CourseControllerDocs.java
@@ -3,12 +3,14 @@ package com.opendata.docs;
 import com.opendata.domain.course.dto.response.CourseComponentDto;
 import com.opendata.domain.course.dto.response.CourseResponse;
 import com.opendata.global.response.ApiResponse;
+import com.opendata.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -58,6 +60,7 @@ public interface CourseControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<List<CourseResponse>>> findCourses(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam double lat,
             @RequestParam double lon,
             @RequestParam String startTime,
@@ -88,6 +91,7 @@ public interface CourseControllerDocs {
             )
     })
     ResponseEntity<ApiResponse<Void>> postCourseLike(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable String courseId
     );
 //

--- a/src/main/java/com/opendata/docs/MyPageControllerDocs.java
+++ b/src/main/java/com/opendata/docs/MyPageControllerDocs.java
@@ -1,0 +1,243 @@
+package com.opendata.docs;
+
+
+import com.opendata.domain.course.dto.response.CourseHistoryResponse;
+import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
+import com.opendata.domain.user.dto.UserResponse;
+import com.opendata.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "마이페이지 API")
+public interface MyPageControllerDocs {
+    @Operation(summary = "과거 코스 조회", description = "현재 코스 포함 사용자 코스 전체 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 코스 조회 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "인증 실패 응답",
+                                    summary = "유효하지 않은 토큰 또는 로그인 필요",
+                                    value = """
+            {
+              "success": false,
+              "code": "COMMON_401",
+              "message": "인증이 필요합니다."
+            }
+            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 에러",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "서버 에러 응답",
+                                    summary = "예상치 못한 서버 에러",
+                                    value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 에러, 관리자에게 문의 바랍니다."
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<com.opendata.global.response.ApiResponse<List<CourseHistoryResponse>>> findCourses(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
+
+    @Operation(summary = "사용자 선호 관광지 추가", description = "사용자가 선호하는 관광지 5개만 추가")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 선호 관광지 추가 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "인증 실패 응답",
+                                    summary = "유효하지 않은 토큰 또는 로그인 필요",
+                                    value = """
+            {
+              "success": false,
+              "code": "COMMON_401",
+              "message": "인증이 필요합니다."
+            }
+            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 에러",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "서버 에러 응답",
+                                    summary = "예상치 못한 서버 에러",
+                                    value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 에러, 관리자에게 문의 바랍니다."
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<com.opendata.global.response.ApiResponse<Void>> updateTourSpot(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam Long tourSpotId
+    );
+
+    @Operation(summary = "사용자 선호 관광지 조회", description = "사용자가 선호하는 관광지 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 선호 관광지 조회 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "인증 실패 응답",
+                                    summary = "유효하지 않은 토큰 또는 로그인 필요",
+                                    value = """
+            {
+              "success": false,
+              "code": "COMMON_401",
+              "message": "인증이 필요합니다."
+            }
+            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 에러",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "서버 에러 응답",
+                                    summary = "예상치 못한 서버 에러",
+                                    value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 에러, 관리자에게 문의 바랍니다."
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<com.opendata.global.response.ApiResponse<List<TourSpotDetailResponse>>> findTourSpot(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
+
+    @Operation(summary = "사용자 선호 관광지 삭제", description = "사용자가 선호 관광지 삭제 가능")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 선호 관광지 삭제 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "인증 실패 응답",
+                                    summary = "유효하지 않은 토큰 또는 로그인 필요",
+                                    value = """
+            {
+              "success": false,
+              "code": "COMMON_401",
+              "message": "인증이 필요합니다."
+            }
+            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 에러",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "서버 에러 응답",
+                                    summary = "예상치 못한 서버 에러",
+                                    value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 에러, 관리자에게 문의 바랍니다."
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<com.opendata.global.response.ApiResponse<Void>> deleteTourSpot(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam Long tourSpotId
+    );
+
+    @Operation(summary = "사용자 조회", description = "사용자 정보(이메일, 멤버쉽, 이름) 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "인증 실패 응답",
+                                    summary = "유효하지 않은 토큰 또는 로그인 필요",
+                                    value = """
+            {
+              "success": false,
+              "code": "COMMON_401",
+              "message": "인증이 필요합니다."
+            }
+            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 에러",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "서버 에러 응답",
+                                    summary = "예상치 못한 서버 에러",
+                                    value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 에러, 관리자에게 문의 바랍니다."
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<com.opendata.global.response.ApiResponse<UserResponse>> findUser(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    );
+}

--- a/src/main/java/com/opendata/domain/course/controller/CourseController.java
+++ b/src/main/java/com/opendata/domain/course/controller/CourseController.java
@@ -7,8 +7,10 @@ import com.opendata.domain.course.service.CourseService;
 
 import com.opendata.global.response.ApiResponse;
 
+import com.opendata.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,7 +23,7 @@ public class CourseController implements CourseControllerDocs {
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<CourseResponse>>> findCourses(
-            //@AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestParam double lat,
             @RequestParam double lon,
             @RequestParam String startTime,
@@ -34,9 +36,9 @@ public class CourseController implements CourseControllerDocs {
 
     @PostMapping("/like/{courseId}")
     public ResponseEntity<ApiResponse<Void>> postCourseLike(
-//            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable String courseId){
-        courseService.likeCourse(courseId);
+        courseService.likeCourse(courseId,customUserDetails);
         return ResponseEntity.ok(ApiResponse.onSuccessVoid());
     }
 //

--- a/src/main/java/com/opendata/domain/course/dto/response/CourseComponentHistoryDto.java
+++ b/src/main/java/com/opendata/domain/course/dto/response/CourseComponentHistoryDto.java
@@ -1,0 +1,13 @@
+package com.opendata.domain.course.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record CourseComponentHistoryDto(
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        String tourSpotTime,
+        String tourSpotName,
+        Long tourspotId,
+        Double lat, Double lon)
+{
+
+}

--- a/src/main/java/com/opendata/domain/course/dto/response/CourseHistoryResponse.java
+++ b/src/main/java/com/opendata/domain/course/dto/response/CourseHistoryResponse.java
@@ -1,0 +1,12 @@
+package com.opendata.domain.course.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CourseHistoryResponse(
+        String courseId,
+        LocalDateTime startDtm,
+        LocalDateTime endDtm,
+        List<CourseComponentHistoryDto> history
+) {
+}

--- a/src/main/java/com/opendata/domain/course/mapper/CourseHistoryMapper.java
+++ b/src/main/java/com/opendata/domain/course/mapper/CourseHistoryMapper.java
@@ -1,0 +1,36 @@
+package com.opendata.domain.course.mapper;
+
+import com.opendata.domain.course.dto.response.CourseComponentHistoryDto;
+import com.opendata.domain.course.dto.response.CourseHistoryResponse;
+import com.opendata.domain.course.entity.Course;
+import com.opendata.domain.course.entity.CourseComponent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(
+        componentModel = SPRING,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface CourseHistoryMapper {
+
+    @Mapping(target = "courseId", source = "course.id")
+    @Mapping(target = "startDtm", source = "course.startDtm")
+    @Mapping(target = "endDtm", source = "course.endDtm")
+    @Mapping(target = "history", source = "components")
+    CourseHistoryResponse toHistoryResponse(Course course, List<CourseComponentHistoryDto> components);
+
+
+    @Mapping(target = "tourSpotTime", source = "tourspotTm", dateFormat = "yyyy-MM-dd HH:mm:ss")
+    @Mapping(target = "tourSpotName", source = "tourSpot.tourspotNm")
+    @Mapping(target = "tourspotId", source = "tourSpot.tourspotId")
+    @Mapping(target = "lat", source = "tourSpot.address.latitude")
+    @Mapping(target = "lon", source = "tourSpot.address.longitude")
+    CourseComponentHistoryDto toHistoryDto(CourseComponent component);
+
+
+}

--- a/src/main/java/com/opendata/domain/course/repository/CourseComponentRepository.java
+++ b/src/main/java/com/opendata/domain/course/repository/CourseComponentRepository.java
@@ -1,9 +1,14 @@
 package com.opendata.domain.course.repository;
 
 import com.opendata.domain.course.entity.CourseComponent;
+import com.opendata.domain.course.repository.custom.CustomCourseComponentRepository;
+import com.opendata.domain.course.repository.custom.CustomCourseRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface CourseComponentRepository extends JpaRepository<CourseComponent, Long> {
+public interface CourseComponentRepository extends JpaRepository<CourseComponent, Long> , CustomCourseComponentRepository {
+
 }

--- a/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseComponentRepository.java
+++ b/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseComponentRepository.java
@@ -1,0 +1,10 @@
+package com.opendata.domain.course.repository.custom;
+
+import com.opendata.domain.course.entity.CourseComponent;
+
+import java.util.List;
+
+public interface CustomCourseComponentRepository
+{
+    List<CourseComponent> findAllByCourseId(Long courseId);
+}

--- a/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseComponentRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseComponentRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.opendata.domain.course.repository.custom;
+
+import com.opendata.domain.course.entity.CourseComponent;
+import com.opendata.domain.course.entity.QCourse;
+import com.opendata.domain.course.entity.QCourseComponent;
+import com.opendata.domain.tourspot.entity.QTourSpot;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomCourseComponentRepositoryImpl implements CustomCourseComponentRepository {
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public List<CourseComponent> findAllByCourseId(Long courseId) {
+        QCourseComponent cc = QCourseComponent.courseComponent;
+        QTourSpot ts = QTourSpot.tourSpot;
+
+        return queryFactory
+                .selectFrom(cc)
+                .leftJoin(cc.tourSpot, ts).fetchJoin()
+                .where(cc.course.id.eq(courseId))
+                .orderBy(cc.tourspotTm.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseRepository.java
+++ b/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseRepository.java
@@ -1,6 +1,10 @@
 package com.opendata.domain.course.repository.custom;
 
 
-public interface CustomCourseRepository {
+import com.opendata.domain.course.entity.Course;
 
+import java.util.List;
+
+public interface CustomCourseRepository {
+    List<Course> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/course/repository/custom/CustomCourseRepositoryImpl.java
@@ -1,6 +1,11 @@
 package com.opendata.domain.course.repository.custom;
 
 
+import com.opendata.domain.course.entity.Course;
+import com.opendata.domain.course.entity.QCourse;
+import com.opendata.domain.course.entity.QCourseComponent;
+import com.opendata.domain.tourspot.entity.QTourSpot;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -8,4 +13,21 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CustomCourseRepositoryImpl implements CustomCourseRepository{
 
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Course> findAllByUserId(Long userId) {
+        QCourse c = QCourse.course;
+        QCourseComponent cc = QCourseComponent.courseComponent;
+        QTourSpot ts = QTourSpot.tourSpot;
+
+        return queryFactory
+                .selectDistinct(c)
+                .from(c)
+                .leftJoin(c.courseComponents, cc).fetchJoin()
+                .leftJoin(cc.tourSpot, ts).fetchJoin()
+                .where(c.user.id.eq(userId))
+                .orderBy(c.startDtm.desc(), cc.tourspotTm.asc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/opendata/domain/course/service/CourseService.java
+++ b/src/main/java/com/opendata/domain/course/service/CourseService.java
@@ -26,6 +26,7 @@ import com.opendata.domain.user.entity.User;
 import com.opendata.domain.user.repository.UserRepository;
 
 
+import com.opendata.global.security.CustomUserDetails;
 import com.opendata.global.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -209,8 +210,9 @@ public class CourseService {
     }
 
     @Transactional
-    public void likeCourse(String courseId) {
-        User user = userRepository.findById(1L).orElseThrow();
+    public void likeCourse(String courseId, CustomUserDetails customUserDetails) {
+        String email = customUserDetails.getUserEmail();
+        User user = userRepository.findUserByEmail(email);
         ObjectMapper objectMapper = new ObjectMapper();
 
         List<?> rawList = (List<?>) redisTemplate.opsForValue().get("tempCourse:" + courseId);

--- a/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
+++ b/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
@@ -1,18 +1,15 @@
 package com.opendata.domain.mypage.controller;
 
 import com.opendata.domain.course.dto.response.CourseHistoryResponse;
-import com.opendata.domain.course.dto.response.CourseResponse;
-import com.opendata.domain.course.entity.Course;
 import com.opendata.domain.mypage.service.MypageService;
+import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
+import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.global.response.ApiResponse;
 import com.opendata.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -29,4 +26,19 @@ public class MypageController
     ){
         return ResponseEntity.ok(ApiResponse.onSuccess(mypageService.getCourses(customUserDetails)));
     }
+    @PostMapping("/preferences")
+    public ResponseEntity<ApiResponse<Void>> updateTourSpot(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam Long tourSpotId
+    ){
+        mypageService.saveUserTourSpot(customUserDetails,tourSpotId);
+        return ResponseEntity.ok(ApiResponse.onSuccessVoid());
+    }
+    @GetMapping("/preferences")
+    public ResponseEntity<ApiResponse<List<TourSpotDetailResponse>>> findTourSpot(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        return ResponseEntity.ok(ApiResponse.onSuccess(mypageService.getTourSpotDetail(customUserDetails)));
+    }
+
 }

--- a/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
+++ b/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
@@ -1,5 +1,6 @@
 package com.opendata.domain.mypage.controller;
 
+import com.opendata.docs.MyPageControllerDocs;
 import com.opendata.domain.course.dto.response.CourseHistoryResponse;
 import com.opendata.domain.mypage.service.MypageService;
 import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
@@ -17,7 +18,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/mypage")
-public class MypageController
+public class MypageController implements MyPageControllerDocs
 {
     private final MypageService mypageService;
 

--- a/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
+++ b/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
@@ -1,0 +1,32 @@
+package com.opendata.domain.mypage.controller;
+
+import com.opendata.domain.course.dto.response.CourseHistoryResponse;
+import com.opendata.domain.course.dto.response.CourseResponse;
+import com.opendata.domain.course.entity.Course;
+import com.opendata.domain.mypage.service.MypageService;
+import com.opendata.global.response.ApiResponse;
+import com.opendata.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage")
+public class MypageController
+{
+    private final MypageService mypageService;
+
+    @GetMapping("/courses")
+    public ResponseEntity<ApiResponse<List<CourseHistoryResponse>>> findCourses(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        return ResponseEntity.ok(ApiResponse.onSuccess(mypageService.getCourses(customUserDetails)));
+    }
+}

--- a/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
+++ b/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
@@ -40,5 +40,13 @@ public class MypageController
     ){
         return ResponseEntity.ok(ApiResponse.onSuccess(mypageService.getTourSpotDetail(customUserDetails)));
     }
+    @DeleteMapping("/preferences")
+    public ResponseEntity<ApiResponse<Void>> deleteTourSpot(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam Long tourSpotId
+    ){
+        mypageService.deleteTourSpot(customUserDetails,tourSpotId);
+        return ResponseEntity.ok(ApiResponse.onSuccessVoid());
+    }
 
 }

--- a/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
+++ b/src/main/java/com/opendata/domain/mypage/controller/MypageController.java
@@ -4,6 +4,7 @@ import com.opendata.domain.course.dto.response.CourseHistoryResponse;
 import com.opendata.domain.mypage.service.MypageService;
 import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
 import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.user.dto.UserResponse;
 import com.opendata.global.response.ApiResponse;
 import com.opendata.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +49,16 @@ public class MypageController
         mypageService.deleteTourSpot(customUserDetails,tourSpotId);
         return ResponseEntity.ok(ApiResponse.onSuccessVoid());
     }
+    @GetMapping("/user")
+    public ResponseEntity<ApiResponse<UserResponse>> findUser(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ){
+        return ResponseEntity.ok(ApiResponse.onSuccess(mypageService.getUser(customUserDetails)));
+    }
+
+
+
+
+
 
 }

--- a/src/main/java/com/opendata/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/opendata/domain/mypage/service/MypageService.java
@@ -25,6 +25,8 @@ import com.opendata.domain.tourspot.repository.CurrentCongestionRepository;
 import com.opendata.domain.tourspot.repository.TourSpotComponentRepository;
 import com.opendata.domain.tourspot.repository.TourSpotRepository;
 import com.opendata.domain.tourspot.service.TourSpotService;
+import com.opendata.global.response.exception.GlobalException;
+import com.opendata.global.response.status.ErrorStatus;
 import com.opendata.global.security.CustomUserDetails;
 import com.opendata.global.util.DateUtil;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +68,12 @@ public class MypageService {
     public void saveUserTourSpot(CustomUserDetails customUserDetails,Long tourSpotId)
     {
         Long userId = customUserDetails.getUserId();
+        if (tourSpotComponentRepository.existsByUserIdAndTourSpotId(userId, tourSpotId)) {
+            throw new GlobalException(ErrorStatus.TOURSPOT_ALREADY_EXISTS);
+        }
+        if (tourSpotComponentRepository.countByUserId(userId) >= 5) {
+            throw new GlobalException(ErrorStatus.TOURSPOT_EXCEEDS);
+        }
         TourSpotComponent tourSpotComponent = TourSpotComponent.toTourSpotComponent(userId, tourSpotId);
         tourSpotComponentRepository.save(tourSpotComponent);
     }

--- a/src/main/java/com/opendata/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/opendata/domain/mypage/service/MypageService.java
@@ -1,5 +1,6 @@
 package com.opendata.domain.mypage.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.opendata.domain.course.dto.response.CourseComponentDto;
 import com.opendata.domain.course.dto.response.CourseComponentHistoryDto;
 import com.opendata.domain.course.dto.response.CourseHistoryResponse;
@@ -11,20 +12,37 @@ import com.opendata.domain.course.mapper.CourseHistoryMapper;
 import com.opendata.domain.course.repository.CourseComponentRepository;
 import com.opendata.domain.course.repository.CourseRepository;
 import com.opendata.domain.course.service.CourseService;
+import com.opendata.domain.tourspot.dto.AddressDto;
+import com.opendata.domain.tourspot.dto.TourSpotEventDto;
+import com.opendata.domain.tourspot.dto.TourSpotTagDto;
+import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotComponent;
+import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
 import com.opendata.domain.tourspot.mapper.CourseResponseMapper;
+import com.opendata.domain.tourspot.mapper.TourSpotDetailMapper;
+import com.opendata.domain.tourspot.repository.CurrentCongestionRepository;
+import com.opendata.domain.tourspot.repository.TourSpotComponentRepository;
+import com.opendata.domain.tourspot.repository.TourSpotRepository;
+import com.opendata.domain.tourspot.service.TourSpotService;
 import com.opendata.global.security.CustomUserDetails;
+import com.opendata.global.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MypageService {
     private final CourseRepository courseRepository;
-    private final CourseComponentRepository courseComponentRepository;
+    private final TourSpotComponentRepository tourSpotComponentRepository;
+
+    private final TourSpotService tourSpotService;
 
     private final CourseHistoryMapper courseHistoryMapper;
+    private final TourSpotDetailMapper tourSpotDetailMapper;
 
     public List<CourseHistoryResponse> getCourses(CustomUserDetails customUserDetails)
     {
@@ -44,6 +62,27 @@ public class MypageService {
                 .toList();
 
 
+    }
+    public void saveUserTourSpot(CustomUserDetails customUserDetails,Long tourSpotId)
+    {
+        Long userId = customUserDetails.getUserId();
+        TourSpotComponent tourSpotComponent = TourSpotComponent.toTourSpotComponent(userId, tourSpotId);
+        tourSpotComponentRepository.save(tourSpotComponent);
+    }
+
+    public List<TourSpotDetailResponse> getTourSpotDetail(CustomUserDetails customUserDetails)
+    {
+        Long userId= customUserDetails.getUserId();
+        return tourSpotComponentRepository.findAllByUserId(userId).stream()
+                .map(tourSpotComponent -> {
+                    try {
+                        return tourSpotService.combineTourSpotDetail(tourSpotComponent.getTourSpotId());
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                })
+                .collect(Collectors.toList());
 
     }
 }

--- a/src/main/java/com/opendata/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/opendata/domain/mypage/service/MypageService.java
@@ -25,6 +25,9 @@ import com.opendata.domain.tourspot.repository.CurrentCongestionRepository;
 import com.opendata.domain.tourspot.repository.TourSpotComponentRepository;
 import com.opendata.domain.tourspot.repository.TourSpotRepository;
 import com.opendata.domain.tourspot.service.TourSpotService;
+import com.opendata.domain.user.dto.UserResponse;
+import com.opendata.domain.user.entity.User;
+import com.opendata.domain.user.repository.UserRepository;
 import com.opendata.global.response.exception.GlobalException;
 import com.opendata.global.response.status.ErrorStatus;
 import com.opendata.global.security.CustomUserDetails;
@@ -41,6 +44,7 @@ import java.util.stream.Collectors;
 public class MypageService {
     private final CourseRepository courseRepository;
     private final TourSpotComponentRepository tourSpotComponentRepository;
+    private final UserRepository userRepository;
 
     private final TourSpotService tourSpotService;
 
@@ -100,5 +104,16 @@ public class MypageService {
     {
         Long userId= customUserDetails.getUserId();
         tourSpotComponentRepository.deleteByUserIdAndTourSpotId(userId, tourSpotId);
+    }
+
+    public UserResponse getUser(CustomUserDetails customUserDetails)
+    {
+        User user= userRepository.findUserByEmail(customUserDetails.getEmail());
+        if(user==null){
+            throw new GlobalException(ErrorStatus.USER_NOT_FOUND);
+        }
+        return UserResponse.toUserResponse(user.getEmail(),user.getMembership(),user.getName());
+
+
     }
 }

--- a/src/main/java/com/opendata/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/opendata/domain/mypage/service/MypageService.java
@@ -29,6 +29,7 @@ import com.opendata.global.response.exception.GlobalException;
 import com.opendata.global.response.status.ErrorStatus;
 import com.opendata.global.security.CustomUserDetails;
 import com.opendata.global.util.DateUtil;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -65,6 +66,7 @@ public class MypageService {
 
 
     }
+    @Transactional
     public void saveUserTourSpot(CustomUserDetails customUserDetails,Long tourSpotId)
     {
         Long userId = customUserDetails.getUserId();
@@ -92,5 +94,11 @@ public class MypageService {
                 })
                 .collect(Collectors.toList());
 
+    }
+    @Transactional
+    public void deleteTourSpot(CustomUserDetails customUserDetails, Long tourSpotId)
+    {
+        Long userId= customUserDetails.getUserId();
+        tourSpotComponentRepository.deleteByUserIdAndTourSpotId(userId, tourSpotId);
     }
 }

--- a/src/main/java/com/opendata/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/opendata/domain/mypage/service/MypageService.java
@@ -1,0 +1,49 @@
+package com.opendata.domain.mypage.service;
+
+import com.opendata.domain.course.dto.response.CourseComponentDto;
+import com.opendata.domain.course.dto.response.CourseComponentHistoryDto;
+import com.opendata.domain.course.dto.response.CourseHistoryResponse;
+import com.opendata.domain.course.dto.response.CourseResponse;
+import com.opendata.domain.course.entity.Course;
+import com.opendata.domain.course.entity.CourseComponent;
+import com.opendata.domain.course.mapper.CourseComponentMapper;
+import com.opendata.domain.course.mapper.CourseHistoryMapper;
+import com.opendata.domain.course.repository.CourseComponentRepository;
+import com.opendata.domain.course.repository.CourseRepository;
+import com.opendata.domain.course.service.CourseService;
+import com.opendata.domain.tourspot.mapper.CourseResponseMapper;
+import com.opendata.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class MypageService {
+    private final CourseRepository courseRepository;
+    private final CourseComponentRepository courseComponentRepository;
+
+    private final CourseHistoryMapper courseHistoryMapper;
+
+    public List<CourseHistoryResponse> getCourses(CustomUserDetails customUserDetails)
+    {
+        Long userId = customUserDetails.getUserId();
+
+        return courseRepository.findAllByUserId(userId).stream()
+                .map(course -> {
+                    var components = Optional.ofNullable(course.getCourseComponents())
+                            .orElseGet(Collections::emptyList);
+
+                    var history = components.stream()
+                            .map(courseHistoryMapper::toHistoryDto)
+                            .toList();
+
+                    return courseHistoryMapper.toHistoryResponse(course, history);
+                })
+                .toList();
+
+
+
+    }
+}

--- a/src/main/java/com/opendata/domain/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/opendata/domain/oauth2/service/CustomOAuth2UserService.java
@@ -41,7 +41,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService
         User existData= userRepository.findUserByEmail(oAuth2Response.getEmail());
         if (existData == null) {
 
-            User user= User.create(oAuth2Response.getEmail(),oAuth2Response.getName(),1L);
+            User user= User.create(oAuth2Response.getEmail(),oAuth2Response.getName(),FREE);
             userRepository.save(user);
 
             UserDto userDTO = new UserDto();

--- a/src/main/java/com/opendata/domain/tourspot/entity/TourSpotComponent.java
+++ b/src/main/java/com/opendata/domain/tourspot/entity/TourSpotComponent.java
@@ -8,7 +8,12 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Data
-@Table(name = "tourspot_component")
+@Table(
+        name = "tourspot_component",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_tourspot", columnNames = {"user_id", "tour_spot_id"})
+        }
+)
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/opendata/domain/tourspot/entity/TourSpotComponent.java
+++ b/src/main/java/com/opendata/domain/tourspot/entity/TourSpotComponent.java
@@ -1,0 +1,34 @@
+package com.opendata.domain.tourspot.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Table(name = "tourspot_component")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+// 성능 문제로 FK만 둠
+public class TourSpotComponent
+{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Long tourSpotId;
+
+
+    public static TourSpotComponent toTourSpotComponent(Long userId, Long tourSpotId) {
+        return TourSpotComponent.builder()
+                .tourSpotId(tourSpotId)
+                .userId(userId)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/CurrentCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/CurrentCongestionRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
-import com.opendata.domain.tourspot.repository.custom.CustomCurrentCongestionRepository;
+import com.opendata.domain.tourspot.repository.custom.currentCongestion.CustomCurrentCongestionRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/FutureCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/FutureCongestionRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpotFutureCongestion;
-import com.opendata.domain.tourspot.repository.custom.CustomFutureCongestionRepository;
+import com.opendata.domain.tourspot.repository.custom.futureCongestion.CustomFutureCongestionRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/MonthlyCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/MonthlyCongestionRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
-import com.opendata.domain.tourspot.repository.custom.montlyCongestion.CustomMonthlyCongestionRepository;
+import com.opendata.domain.tourspot.repository.custom.monthlyCongestion.CustomMonthlyCongestionRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/MonthlyCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/MonthlyCongestionRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
-import com.opendata.domain.tourspot.repository.custom.CustomMonthlyCongestionRepository;
+import com.opendata.domain.tourspot.repository.custom.montlyCongestion.CustomMonthlyCongestionRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/TourSpotComponentRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/TourSpotComponentRepository.java
@@ -1,0 +1,10 @@
+package com.opendata.domain.tourspot.repository;
+
+import com.opendata.domain.tourspot.entity.TourSpotComponent;
+import com.opendata.domain.tourspot.repository.custom.component.CustomTourSpotComponentRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TourSpotComponentRepository extends JpaRepository<TourSpotComponent,Long> , CustomTourSpotComponentRepository {
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/TourSpotEventRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/TourSpotEventRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpotEvent;
-import com.opendata.domain.tourspot.repository.custom.CustomTourSpotEventRepository;
+import com.opendata.domain.tourspot.repository.custom.event.CustomTourSpotEventRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/opendata/domain/tourspot/repository/TourSpotRelatedRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/TourSpotRelatedRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpotRelated;
-import com.opendata.domain.tourspot.repository.custom.CustomTourSpotRelatedRepository;
+import com.opendata.domain.tourspot.repository.custom.related.CustomTourSpotRelatedRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/TourSpotRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/TourSpotRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpot;
-import com.opendata.domain.tourspot.repository.custom.CustomTourSpotRepository;
+import com.opendata.domain.tourspot.repository.custom.tourSpot.CustomTourSpotRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/TourSpotTagRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/TourSpotTagRepository.java
@@ -1,7 +1,7 @@
 package com.opendata.domain.tourspot.repository;
 
 import com.opendata.domain.tourspot.entity.TourSpotTag;
-import com.opendata.domain.tourspot.repository.custom.CustomTourSpotTagRepository;
+import com.opendata.domain.tourspot.repository.custom.tag.CustomTourSpotTagRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotComponentRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotComponentRepository.java
@@ -1,5 +1,4 @@
 package com.opendata.domain.tourspot.repository.custom;
 
-public interface CustomTourSpotRelatedRepository {
-
+public interface CustomTourSpotComponentRepository {
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotComponentRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/CustomTourSpotComponentRepository.java
@@ -1,4 +1,0 @@
-package com.opendata.domain.tourspot.repository.custom;
-
-public interface CustomTourSpotComponentRepository {
-}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepository.java
@@ -9,4 +9,6 @@ public interface CustomTourSpotComponentRepository {
     boolean existsByUserIdAndTourSpotId(Long userId, Long tourSpotId);
 
     long countByUserId(Long userId);
+
+    void deleteByUserIdAndTourSpotId(Long userId, Long tourSpotId);
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepository.java
@@ -1,0 +1,9 @@
+package com.opendata.domain.tourspot.repository.custom.component;
+
+import com.opendata.domain.tourspot.entity.TourSpotComponent;
+
+import java.util.List;
+
+public interface CustomTourSpotComponentRepository {
+    List<TourSpotComponent> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepository.java
@@ -6,4 +6,7 @@ import java.util.List;
 
 public interface CustomTourSpotComponentRepository {
     List<TourSpotComponent> findAllByUserId(Long userId);
+    boolean existsByUserIdAndTourSpotId(Long userId, Long tourSpotId);
+
+    long countByUserId(Long userId);
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.opendata.domain.tourspot.repository.custom.component;
+
+import com.opendata.domain.tourspot.entity.QTourSpotComponent;
+import com.opendata.domain.tourspot.entity.TourSpot;
+import com.opendata.domain.tourspot.entity.TourSpotComponent;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomTourSpotComponentRepositoryImpl implements CustomTourSpotComponentRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<TourSpotComponent> findAllByUserId(Long userId) {
+        QTourSpotComponent q = QTourSpotComponent.tourSpotComponent;
+        return queryFactory
+                .selectFrom(q)
+                .where(q.userId.eq(userId))
+                .distinct()
+                .fetch();
+    }
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepositoryImpl.java
@@ -46,4 +46,13 @@ public class CustomTourSpotComponentRepositoryImpl implements CustomTourSpotComp
                 .where(q.userId.eq(userId))
                 .fetchOne();
     }
+
+    @Override
+    public void deleteByUserIdAndTourSpotId(Long userId, Long tourSpotId) {
+        QTourSpotComponent q = QTourSpotComponent.tourSpotComponent;
+        queryFactory
+                .delete(q)
+                .where(q.userId.eq(userId), q.tourSpotId.eq(tourSpotId))
+                .execute();
+    }
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/component/CustomTourSpotComponentRepositoryImpl.java
@@ -21,4 +21,29 @@ public class CustomTourSpotComponentRepositoryImpl implements CustomTourSpotComp
                 .distinct()
                 .fetch();
     }
+
+    @Override
+    public boolean existsByUserIdAndTourSpotId(Long userId, Long tourSpotId) {
+        QTourSpotComponent q = QTourSpotComponent.tourSpotComponent;
+        Integer fetchOne = queryFactory
+                .selectOne()
+                .from(q)
+                .where(
+                        q.userId.eq(userId)
+                                .and(q.tourSpotId.eq(tourSpotId))
+                )
+                .fetchFirst(); // limit 1
+
+        return fetchOne != null;
+    }
+
+    @Override
+    public long countByUserId(Long userId) {
+        QTourSpotComponent q = QTourSpotComponent.tourSpotComponent;
+        return queryFactory
+                .select(q.count())
+                .from(q)
+                .where(q.userId.eq(userId))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/currentCongestion/CustomCurrentCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/currentCongestion/CustomCurrentCongestionRepository.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.currentCongestion;
 
 import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/currentCongestion/CustomCurrentCongestionRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/currentCongestion/CustomCurrentCongestionRepositoryImpl.java
@@ -1,16 +1,15 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.currentCongestion;
 
 import com.opendata.domain.tourspot.entity.QTourSpotCurrentCongestion;
 import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
-import com.querydsl.core.QueryFactory;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomCurrentCongestionRepositoryImpl implements CustomCurrentCongestionRepository{
+public class CustomCurrentCongestionRepositoryImpl implements CustomCurrentCongestionRepository {
 
     private final JPAQueryFactory queryFactory;
     @Override

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/event/CustomTourSpotEventRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/event/CustomTourSpotEventRepository.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.event;
 
 import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.domain.tourspot.entity.TourSpotEvent;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/event/CustomTourSpotEventRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/event/CustomTourSpotEventRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.event;
 
 import com.opendata.domain.tourspot.entity.QTourSpotEvent;
 import com.opendata.domain.tourspot.entity.TourSpot;
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomTourSpotEventRepositoryImpl implements CustomTourSpotEventRepository{
+public class CustomTourSpotEventRepositoryImpl implements CustomTourSpotEventRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/futureCongestion/CustomFutureCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/futureCongestion/CustomFutureCongestionRepository.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.futureCongestion;
 
 import com.opendata.domain.tourspot.entity.TourSpotFutureCongestion;
 import com.opendata.domain.tourspot.entity.enums.CongestionLevel;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/futureCongestion/CustomFutureCongestionRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/futureCongestion/CustomFutureCongestionRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.futureCongestion;
 
 import com.opendata.domain.tourspot.entity.QTourSpotFutureCongestion;
 import com.opendata.domain.tourspot.entity.TourSpotFutureCongestion;
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomFutureCongestionRepositoryImpl implements CustomFutureCongestionRepository{
+public class CustomFutureCongestionRepositoryImpl implements CustomFutureCongestionRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepository.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom.montlyCongestion;
+package com.opendata.domain.tourspot.repository.custom.monthlyCongestion;
 
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom.montlyCongestion;
+package com.opendata.domain.tourspot.repository.custom.monthlyCongestion;
 
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/montlyCongestion/CustomMonthlyCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/montlyCongestion/CustomMonthlyCongestionRepository.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.montlyCongestion;
 
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/montlyCongestion/CustomMonthlyCongestionRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/montlyCongestion/CustomMonthlyCongestionRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.montlyCongestion;
 
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/related/CustomTourSpotRelatedRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/related/CustomTourSpotRelatedRepository.java
@@ -1,0 +1,5 @@
+package com.opendata.domain.tourspot.repository.custom.related;
+
+public interface CustomTourSpotRelatedRepository {
+
+}

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/related/CustomTourSpotRelatedRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/related/CustomTourSpotRelatedRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.related;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/tag/CustomTourSpotTagRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/tag/CustomTourSpotTagRepository.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.tag;
 
 import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.domain.tourspot.entity.TourSpotTag;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/tag/CustomTourSpotTagRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/tag/CustomTourSpotTagRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.tag;
 
 import com.opendata.domain.tourspot.entity.QTourSpotTag;
 import com.opendata.domain.tourspot.entity.TourSpot;
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomTourSpotTagRepositoryImpl implements CustomTourSpotTagRepository{
+public class CustomTourSpotTagRepositoryImpl implements CustomTourSpotTagRepository {
     private final JPAQueryFactory queryFactory;
     @Override
     public List<TourSpotTag> findAllByTourSpot(TourSpot tourSpot) {

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/tourSpot/CustomTourSpotRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/tourSpot/CustomTourSpotRepository.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.tourSpot;
 
 import com.opendata.domain.address.entity.Address;
 import com.opendata.domain.tourspot.entity.TourSpot;

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/tourSpot/CustomTourSpotRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/tourSpot/CustomTourSpotRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.opendata.domain.tourspot.repository.custom;
+package com.opendata.domain.tourspot.repository.custom.tourSpot;
 
 import com.opendata.domain.address.entity.Address;
 import com.opendata.domain.tourspot.entity.QTourSpot;
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomTourSpotRepositoryImpl implements CustomTourSpotRepository{
+public class CustomTourSpotRepositoryImpl implements CustomTourSpotRepository {
 
     private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/opendata/domain/tourspot/service/TourSpotService.java
+++ b/src/main/java/com/opendata/domain/tourspot/service/TourSpotService.java
@@ -67,12 +67,16 @@ public class TourSpotService
         List<TourSpotEvent> tourSpotEvents = tourSpotEventRepository.findAllByTourSpot(tourSpot);
         List<TourSpotTag> tourSpotTags = tourSpotTagRepository.findAllByTourSpot(tourSpot);
 
-        System.out.println(tourSpotCurrentCongestion.getCurrentCongestionId());
+        String congestionLabel = null;
+        if (tourSpotCurrentCongestion != null) {
+            congestionLabel = tourSpotCurrentCongestion.getCongestionLvl().getCongestionLabel();
+        }
+
 
         TourSpotDetailResponse t = tourSpotDetailMapper.toResponse(
                 tourSpot,
                 tourSpotDetailMapper.toAddressDto(address),
-                tourSpotCurrentCongestion.getCongestionLvl().getCongestionLabel(),
+                congestionLabel,
                 tourSpotDetailMapper.toEventDtos(tourSpotEvents),
                 tourSpotDetailMapper.toTagDtos(tourSpotTags)
         );

--- a/src/main/java/com/opendata/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/opendata/domain/user/dto/UserResponse.java
@@ -1,0 +1,25 @@
+package com.opendata.domain.user.dto;
+
+
+import com.opendata.domain.user.entity.MemberShip;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponse
+{
+    private String email;
+    private MemberShip membership;
+    private String name;
+
+    public static UserResponse toUserResponse(String email, MemberShip membership, String name)
+    {
+        return UserResponse.builder()
+                .email(email)
+                .membership(membership)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/opendata/domain/user/entity/User.java
+++ b/src/main/java/com/opendata/domain/user/entity/User.java
@@ -20,8 +20,9 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "membership_id", nullable = false)
-    private Long membershipId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "membership", nullable = false)
+    private MemberShip membership;
 
     @Column(name = "user_email")
     private String email;
@@ -32,11 +33,11 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Course> courseList;
 
-    public static User create(String email, String name, Long membershipId) {
+    public static User create(String email, String name, MemberShip membership) {
         return User.builder()
                 .email(email)
                 .name(name)
-                .membershipId(membershipId)
+                .membership(membership)
                 .build();
     }
     public void updateUserInfo(String name) {

--- a/src/main/java/com/opendata/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/opendata/domain/user/repository/UserRepository.java
@@ -1,11 +1,12 @@
 package com.opendata.domain.user.repository;
 
 import com.opendata.domain.user.entity.User;
+import com.opendata.domain.user.repository.custom.CustomUserRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
 
-    User findUserByEmail(String email);
 }

--- a/src/main/java/com/opendata/domain/user/repository/custom/CustomUserRepository.java
+++ b/src/main/java/com/opendata/domain/user/repository/custom/CustomUserRepository.java
@@ -5,4 +5,6 @@ import com.opendata.domain.user.entity.User;
 
 public interface CustomUserRepository {
     User findUserByEmail(String email);
+    User findUserById(Long userId);
+    void deleteUserById(Long userId);
 }

--- a/src/main/java/com/opendata/domain/user/repository/custom/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/user/repository/custom/CustomUserRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.opendata.domain.user.repository.custom;
 
+import com.opendata.domain.user.entity.QUser;
 import com.opendata.domain.user.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -8,8 +10,32 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class CustomUserRepositoryImpl implements CustomUserRepository{
 
+    private final JPAQueryFactory queryFactory;
+
     @Override
     public User findUserByEmail(String email) {
-        return null;
+        QUser u = QUser.user;
+        return queryFactory
+                .selectFrom(u)
+                .where(u.email.eq(email))
+                .fetchFirst();
+    }
+
+    @Override
+    public User findUserById(Long userId) {
+        QUser u = QUser.user;
+        return queryFactory
+                .selectFrom(u)
+                .where(u.id.eq(userId))
+                .fetchFirst();
+    }
+
+    @Override
+    public void deleteUserById(Long userId) {
+        QUser u = QUser.user;
+        queryFactory
+                .delete(u)
+                .where(u.id.eq(userId))
+                .execute();
     }
 }

--- a/src/main/java/com/opendata/global/config/SwaggerConfig.java
+++ b/src/main/java/com/opendata/global/config/SwaggerConfig.java
@@ -1,7 +1,11 @@
 package com.opendata.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,11 +14,32 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        Info info = new Info()
-                .version("v1.0")
-                .title("OpenData API");
+        // Security Scheme 정의 (Bearer JWT)
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization"); // 헤더 이름
+
+        // Security Requirement (전역 적용)
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Authorization");
+
+        // Components에 Security Scheme 등록
+        Components components = new Components()
+                .addSecuritySchemes("Authorization", apiKey);
+
         return new OpenAPI()
-                .info(info);
+                .addServersItem(new Server().url("/")) // 리버스 프록시 등일 때 베이스 경로
+                .components(components)
+                .addSecurityItem(securityRequirement)
+                .info(apiInfo());
     }
 
+    private Info apiInfo() {
+        return new Info()
+                .title("OpenData API")
+                .version("v1.0");
+    }
 }

--- a/src/main/java/com/opendata/global/jwt/JwtFilter.java
+++ b/src/main/java/com/opendata/global/jwt/JwtFilter.java
@@ -30,6 +30,9 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
+        if(accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
 
         try {
             jwtUtil.isExpired(accessToken);

--- a/src/main/java/com/opendata/global/response/status/ErrorStatus.java
+++ b/src/main/java/com/opendata/global/response/status/ErrorStatus.java
@@ -26,7 +26,10 @@ public enum ErrorStatus implements BaseStatusCode {
     ADDRESS_NOT_FOUND(HttpStatus.BAD_REQUEST,"ADDRESS_001","해당 주소가 존재하지 않습니다."),
 
     //관광지
-    TOURSPOT_NOT_FOUND(HttpStatus.BAD_REQUEST,"TOURSPOT_001","해당 관광지가 존재하지 않습니다.");
+    TOURSPOT_NOT_FOUND(HttpStatus.BAD_REQUEST,"TOURSPOT_001","해당 관광지가 존재하지 않습니다."),
+    TOURSPOT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"TOURSPOT_002","해당 관광지가 이미 존재합니다."),
+    TOURSPOT_EXCEEDS(HttpStatus.BAD_REQUEST,"TOURSPOT_003","추가할 수 있는 관광지 개수가 초과되었습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/opendata/global/security/CustomUserDetails.java
+++ b/src/main/java/com/opendata/global/security/CustomUserDetails.java
@@ -47,6 +47,11 @@ public class CustomUserDetails implements UserDetails {
         return user.getEmail();
     }
 
+
+    public String getUserEmail() {
+        return user.getEmail();
+    }
+
     @Override
     public boolean isAccountNonExpired() {
         return true;


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->
- 사용자 별 코스 기록 조회
- 선호 관광지 추가, 삭제, 조회
- 사용자 정보 조회

---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- CourseHistoryMapper 구현
- TourComponent 생성(조회 속도 빠르게 FK만 저장)
- leftJoin 사용(N+1 해결)
- swagger 토큰 연결 
- course 엔티티에 사용자 연결

---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #50 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새로운 기능
  - 마이페이지 API 추가: 코스 이력 조회, 관심 관광지 추가/목록/삭제, 사용자 정보 조회
  - 코스 추천에 종료시간(endTime)·관광지(tourspot) 필터 지원
  - 주요 코스 엔드포인트에 로그인 연동(좋아요 등)
  - 관심 관광지 중복/개수 초과 시 명확한 오류 안내

- 버그 수정
  - JWT Authorization 헤더의 “Bearer ” 접두어 자동 처리
  - 관광지 상세 조회 시 혼잡도 데이터가 없어도 안정적으로 표시

- 문서
  - JWT 보안 스키마 적용으로 전체 API 보안 설정 강화
  - 마이페이지·코스 엔드포인트 문서화 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->