### PR TITLE
[feat] 관광지 상세정보 필드에 30일 혼잡도 추가

### DIFF
--- a/src/main/java/com/opendata/domain/tourspot/dto/TourSpotMonthlyCongestionDto.java
+++ b/src/main/java/com/opendata/domain/tourspot/dto/TourSpotMonthlyCongestionDto.java
@@ -1,0 +1,7 @@
+package com.opendata.domain.tourspot.dto;
+
+public record TourSpotMonthlyCongestionDto(
+	String baseYmd,
+	String congestionLvl
+) {
+}

--- a/src/main/java/com/opendata/domain/tourspot/dto/response/TourSpotDetailResponse.java
+++ b/src/main/java/com/opendata/domain/tourspot/dto/response/TourSpotDetailResponse.java
@@ -3,8 +3,10 @@ package com.opendata.domain.tourspot.dto.response;
 
 import com.opendata.domain.tourspot.dto.AddressDto;
 import com.opendata.domain.tourspot.dto.TourSpotEventDto;
+import com.opendata.domain.tourspot.dto.TourSpotMonthlyCongestionDto;
 import com.opendata.domain.tourspot.dto.TourSpotTagDto;
 import com.opendata.domain.tourspot.entity.TourSpotEvent;
+import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 import com.opendata.domain.tourspot.entity.TourSpotTag;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,4 +25,5 @@ public class TourSpotDetailResponse {
     private String congestionLabel;
     private List<TourSpotEventDto> tourSpotEvents;
     private List<TourSpotTagDto> tourSpotTags;
+    private List<TourSpotMonthlyCongestionDto> tourSpotMonthlyCongestionDtos;
 }

--- a/src/main/java/com/opendata/domain/tourspot/mapper/TourSpotDetailMapper.java
+++ b/src/main/java/com/opendata/domain/tourspot/mapper/TourSpotDetailMapper.java
@@ -4,11 +4,13 @@ import com.opendata.domain.address.entity.Address;
 import com.opendata.domain.tourspot.dto.AddressDto;
 import com.opendata.domain.tourspot.dto.CityDataDto;
 import com.opendata.domain.tourspot.dto.TourSpotEventDto;
+import com.opendata.domain.tourspot.dto.TourSpotMonthlyCongestionDto;
 import com.opendata.domain.tourspot.dto.TourSpotTagDto;
 import com.opendata.domain.tourspot.dto.response.TourSpotDetailResponse;
 import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.domain.tourspot.entity.TourSpotCurrentCongestion;
 import com.opendata.domain.tourspot.entity.TourSpotEvent;
+import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 import com.opendata.domain.tourspot.entity.TourSpotTag;
 import com.opendata.domain.tourspot.entity.enums.CongestionLevel;
 import org.mapstruct.*;
@@ -27,16 +29,19 @@ public interface TourSpotDetailMapper {
     @Mapping(target = "congestionLabel", source = "congestion")
     @Mapping(target = "tourSpotEvents", source = "events")
     @Mapping(target = "tourSpotTags", source = "tags")
+    @Mapping(target = "tourSpotMonthlyCongestionDtos", source = "monthlyCongestions")
     TourSpotDetailResponse toResponse(
             TourSpot tourSpot,
             AddressDto address,
             String congestion,
             List<TourSpotEventDto> events,
-            List<TourSpotTagDto> tags
+            List<TourSpotTagDto> tags,
+            List<TourSpotMonthlyCongestionDto> monthlyCongestions
     );
 
     List<TourSpotEventDto> toEventDtos(List<TourSpotEvent> events);
     List<TourSpotTagDto> toTagDtos(List<TourSpotTag> tags);
     AddressDto toAddressDto(Address address);
+    List<TourSpotMonthlyCongestionDto> toMonthlyCongestionDtos(List<TourSpotMonthlyCongestion> monthlyCongestion);
 
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepository.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepository.java
@@ -1,5 +1,6 @@
 package com.opendata.domain.tourspot.repository.custom.monthlyCongestion;
 
+import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface CustomMonthlyCongestionRepository
 {
     long updateCongestionLevel(List<TourSpotMonthlyCongestion> monthlyCongestions);
+    void deleteMonthlyCongestionsByTourspotId(Long tourspotId);
+    List<TourSpotMonthlyCongestion> findAllByTourspot(TourSpot tourSpot);
 }

--- a/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepositoryImpl.java
+++ b/src/main/java/com/opendata/domain/tourspot/repository/custom/monthlyCongestion/CustomMonthlyCongestionRepositoryImpl.java
@@ -1,7 +1,12 @@
 package com.opendata.domain.tourspot.repository.custom.monthlyCongestion;
 
+import com.opendata.domain.tourspot.entity.QTourSpot;
+import com.opendata.domain.tourspot.entity.QTourSpotMonthlyCongestion;
+import com.opendata.domain.tourspot.entity.TourSpot;
 import com.opendata.domain.tourspot.entity.TourSpotMonthlyCongestion;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -17,4 +22,27 @@ public class CustomMonthlyCongestionRepositoryImpl implements CustomMonthlyConge
     public long updateCongestionLevel(List<TourSpotMonthlyCongestion> monthlyCongestions) {
         return 1L;
     }
+
+    @Override
+    @Transactional
+    public void deleteMonthlyCongestionsByTourspotId(Long tourspotId) {
+        QTourSpotMonthlyCongestion mc = QTourSpotMonthlyCongestion.tourSpotMonthlyCongestion;
+
+        queryFactory
+            .delete(mc)
+            .where(mc.tourspot.tourspotId.eq(tourspotId))
+            .execute();
+    }
+
+    @Override
+    public List<TourSpotMonthlyCongestion> findAllByTourspot(TourSpot tourSpot) {
+        QTourSpotMonthlyCongestion mc = QTourSpotMonthlyCongestion.tourSpotMonthlyCongestion;
+
+        return queryFactory
+            .selectFrom(mc)
+            .where(mc.tourspot.tourspotId.eq(tourSpot.getTourspotId()))
+            .orderBy(mc.baseYmd.asc())
+            .fetch();
+    }
+
 }

--- a/src/main/java/com/opendata/domain/tourspot/service/MonthlyCongestionService.java
+++ b/src/main/java/com/opendata/domain/tourspot/service/MonthlyCongestionService.java
@@ -26,7 +26,7 @@ public class MonthlyCongestionService
     private final WebClient openApiWebClient;
     private final ObjectMapper objectMapper;
 
-    @Value("${api.tour_api_congestion_key}")
+    @Value("${api.tour_api_tourspot_key}")
     private String secretKey;
 
 


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 어떤 내용을 담고 있는지 한 줄로 요약해주세요. -->

- 기존 30일 혼잡도 로직 복구(새벽 3시 업데이트)
- 관광지 상세조회 및 마이페이지 선호 관광지 조회 시 30일 혼잡도 필드 추가
---

## ✅ 변경사항
<!-- 주요 변경사항을 bullet point로 간단히 작성해주세요. -->
- TourSpotDetailMapper에 30일 혼잡도 필드 추가
- updateMonthlyCongestion() 복구 및 새벽 3시 스케줄링 


---

## 🔍 체크리스트
- [x] PR 제목은 명확한가요?
- [x] 관련 이슈가 있다면 연결했나요?
- [x] 로컬 테스트는 통과했나요?
- [x] 코드에 불필요한 부분은 없나요?

---

## 📎 관련 이슈
<!-- 예: Closes #123 -->
Closes #75 

---

## 💬 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보를 적어주세요. 필요 없다면 생략 가능 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 관광지 상세 응답에 월별 혼잡도 정보가 추가되어 더 풍부한 데이터 확인이 가능합니다.
  - 매일 03:00(Asia/Seoul)에 월별 혼잡도 데이터를 자동 수집·갱신하는 스케줄 작업이 도입되었습니다(병렬 처리로 성능 향상).

- Chores
  - 외부 API 비밀키 설정 경로가 업데이트되었습니다.
  - 기존 주소·관광지 일괄 수집 스케줄 작업이 비활성화되었습니다.
  - 데이터 정합성을 위해 월별 혼잡도 갱신 시 기존 데이터를 삭제 후 재생성하도록 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->